### PR TITLE
Update to fabric networking API v1

### DIFF
--- a/src/main/java/draylar/reroll/RerollClient.java
+++ b/src/main/java/draylar/reroll/RerollClient.java
@@ -1,9 +1,8 @@
 package draylar.reroll;
 
-import io.netty.buffer.Unpooled;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
-import net.minecraft.network.PacketByteBuf;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 
 public class RerollClient implements ClientModInitializer {
 
@@ -12,11 +11,11 @@ public class RerollClient implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
-        ClientSidePacketRegistry.INSTANCE.register(Reroll.DATA_RESPONSE, (context, packet) -> {
-            int exp = packet.readInt();
-            int lapis = packet.readInt();
+        ClientPlayNetworking.registerGlobalReceiver(Reroll.DATA_RESPONSE, (client, handler, buf, responseSender) -> {
+            int exp = buf.readInt();
+            int lapis = buf.readInt();
 
-            context.getTaskQueue().execute(() -> {
+            client.execute(() -> {
                 cachedExp = exp;
                 cachedLapis = lapis;
             });
@@ -42,6 +41,6 @@ public class RerollClient implements ClientModInitializer {
     }
 
     private static void requestData() {
-        ClientSidePacketRegistry.INSTANCE.sendToServer(Reroll.DATA_REQUEST, new PacketByteBuf(Unpooled.buffer()));
+        ClientPlayNetworking.send(Reroll.DATA_REQUEST, PacketByteBufs.create());
     }
 }

--- a/src/main/java/draylar/reroll/mixin/EnchantmentScreenMixin.java
+++ b/src/main/java/draylar/reroll/mixin/EnchantmentScreenMixin.java
@@ -2,8 +2,8 @@ package draylar.reroll.mixin;
 
 import draylar.reroll.Reroll;
 import draylar.reroll.RerollClient;
-import io.netty.buffer.Unpooled;
-import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.screen.ingame.EnchantmentScreen;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
@@ -11,9 +11,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.network.PacketByteBuf;
 import net.minecraft.screen.EnchantmentScreenHandler;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
@@ -26,9 +24,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.text.Format;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Mixin(EnchantmentScreen.class)
@@ -128,8 +124,7 @@ public abstract class EnchantmentScreenMixin extends HandledScreen<EnchantmentSc
         int y = (this.height - this.backgroundHeight) / 2 + 73;
 
         if(mouseX >= x && mouseX <= x + 9 && mouseY >= y && mouseY <= y + 9) {
-            PacketByteBuf packet = new PacketByteBuf(Unpooled.buffer());
-            ClientSidePacketRegistry.INSTANCE.sendToServer(Reroll.REROLL_PACKET, packet);
+            ClientPlayNetworking.send(Reroll.REROLL_PACKET, PacketByteBufs.create());
             cir.setReturnValue(true);
         }
     }


### PR DESCRIPTION
and move the rerolling code to a separate `reroll(PlayerEntity player)` method (~~so that I can more easily write a compatibility mixin~~).

P.S. The unified GitHub diff looks god awful, better read the right side of the split view.

P.P.S. Shall I PR an updated gradle build as well?
Auto Config is now part of Cloth and moved host, there's loom 0.6, slightly newer dependencies/mappings and [jcenter has reached EOL](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)